### PR TITLE
Refactor.

### DIFF
--- a/Source/UIImage+Color.m
+++ b/Source/UIImage+Color.m
@@ -123,7 +123,7 @@ float const selectionColorPointCount        = 144;
 - (UIColor *)averageColorForImage:(UIImage *)image {
     
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    unsigned char rgba[4];
+    uint8_t rgba[4];
     CGContextRef context = CGBitmapContextCreate(rgba, 1, 1, 8, 4, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
     
     CGContextDrawImage(context, CGRectMake(0, 0, 1, 1), image.CGImage);
@@ -131,19 +131,12 @@ float const selectionColorPointCount        = 144;
     CGContextRelease(context);
     
     if(rgba[3] == 0) {
-        CGFloat alpha = ((CGFloat)rgba[3])/255.0;
-        CGFloat multiplier = alpha/255.0;
-        return [UIColor colorWithRed:((CGFloat)rgba[0])*multiplier
-                               green:((CGFloat)rgba[1])*multiplier
-                                blue:((CGFloat)rgba[2])*multiplier
-                               alpha:alpha];
+        return UIColor.clearColor;
     }
-    else {
-        return [UIColor colorWithRed:((CGFloat)rgba[0])/255.0
-                               green:((CGFloat)rgba[1])/255.0
-                                blue:((CGFloat)rgba[2])/255.0
-                               alpha:((CGFloat)rgba[3])/255.0];
-    }
+    return [UIColor colorWithRed:rgba[0] / 255.0
+                           green:rgba[1] / 255.0
+                            blue:rgba[2] / 255.0
+                           alpha:rgba[3] / 255.0];
 }
 
 - (UIColor *)primaryColorFromBackgroundColor:(UIColor *)backgroundColor {


### PR DESCRIPTION
Code below: 
```
if(rgba[3] == 0) {
    CGFloat alpha = ((CGFloat)rgba[3])/255.0;
    CGFloat multiplier = alpha/255.0;
    return [UIColor colorWithRed:((CGFloat)rgba[0])*multiplier 
                                          green:((CGFloat)rgba[1])*multiplier
                                            blue:((CGFloat)rgba[2])*multiplier
                                          alpha:alpha];
}
```

could be rewritten as:
```
if(rgba[3] == 0) {
    CGFloat alpha = 0/255.0;
    CGFloat multiplier = 0/255.0;
    return [UIColor colorWithRed:((CGFloat)rgba[0])*0
                                          green:((CGFloat)rgba[1])*0
                                            blue:((CGFloat)rgba[2])*0
                                          alpha:alpha];
}
```

or:
```
if(rgba[3] == 0) {
    return [UIColor clearColor];
}
```
Also, there is no need to do type casting to CGFloat. Type will be inferred automatically because of divisor 255.0.